### PR TITLE
feat: Refine one-time extra payment logic and enhance UI clarity

### DIFF
--- a/src/components/LoanComparison.tsx
+++ b/src/components/LoanComparison.tsx
@@ -1,3 +1,5 @@
+// Updated LoanComparison component
+
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { LoanComparisonProps } from '@/types';
@@ -30,10 +32,10 @@ const LoanComparison: React.FC<LoanComparisonProps> = ({ results, extraPaymentTy
 
   return (
     <View style={styles.container}>
-            <View style={styles.comparisonSectionHeader}>
-              <Text style={styles.comparisonTitle}>Loan Comparison</Text>
-              <InfoButton note="Compare the total interest and total amount paid with and without extra payments." />
-            </View>
+      <View style={styles.comparisonSectionHeader}>
+        <Text style={styles.comparisonTitle}>Loan Comparison</Text>
+        <InfoButton note="Compare the total interest and total amount paid with and without extra payments." />
+      </View>
       
       <View style={styles.comparisonContainer}>
         <ComparisonRow
@@ -44,7 +46,7 @@ const LoanComparison: React.FC<LoanComparisonProps> = ({ results, extraPaymentTy
         />
         
         <ComparisonRow
-          label="Total Amount"
+          label={extraPaymentType === 'oneTime' ? "Total Amount (including upfront payment)" : "Total Amount"}
           regularValue={formatCurrency(results.totalAmountRegular)}
           extraValue={formatCurrency(results.totalAmountExtra)}
           backgroundColor={Colours.background.secondary}
@@ -52,7 +54,7 @@ const LoanComparison: React.FC<LoanComparisonProps> = ({ results, extraPaymentTy
 
         {extraPaymentType && (
           <ComparisonRow
-            label={extraPaymentType === 'oneTime' ? "Monthly Payment (with one-time extra payment)" : "Monthly Payment (with extra payment)"}
+            label={extraPaymentType === 'oneTime' ? "Monthly Payment (after upfront payment)" : "Monthly Payment (with extra payment)"}
             regularValue={formatCurrency(results.monthlyPaymentRegular)}
             extraValue={formatCurrency(results.monthlyPaymentExtra)}
             backgroundColor={Colours.background.accent}
@@ -81,7 +83,7 @@ const LoanComparison: React.FC<LoanComparisonProps> = ({ results, extraPaymentTy
           </>
         )}
       </View>
-    </View >
+    </View>
   );
 };
 
@@ -164,12 +166,12 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: Colours.success,
   },
-    comparisonSectionHeader: {
+  comparisonSectionHeader: {
     flexDirection: 'row',
     alignItems: 'center',
     marginBottom: 16,
   },
-    comparisonTitle: {
+  comparisonTitle: {
     fontSize: 18,
     fontWeight: '600',
     color: Colours.text.primary,

--- a/src/screens/MortgageCalculatorScreen.tsx
+++ b/src/screens/MortgageCalculatorScreen.tsx
@@ -101,155 +101,176 @@ const MortgageCalculatorScreen: React.FC = () => {
 
   return (
     <SafeAreaView style={styles.container}>
-      <KeyboardAvoidingView 
+      <KeyboardAvoidingView
         style={styles.keyboardAvoidingView}
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       >
         <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
-        {/* Header */}
-        <View style={styles.header}>
-          <Ionicons name="calculator" size={32} color={Colours.primary} />
-          <Text style={styles.headerTitle}>Mortgage Calculator</Text>
-          <Text style={styles.headerSubtitle}>
-            Calculate your savings with extra mortgage payments
-          </Text>
-        </View>
-
-        {/* Input Section */}
-        <View style={styles.inputSection}>
-          <View style={styles.sectionHeader}>
-            <Ionicons name="card" size={20} color={Colours.primary} />
-            <Text style={styles.sectionTitle}>Loan Details</Text>
-          </View>
-
-          <InputField
-            label="Loan Amount"
-            value={formatNumberWithCommas(loanAmount)}
-            onChangeText={(text) => setLoanAmount(cleanNumber(text))}
-            placeholder="e.g., 300,000"
-            prefix="$"
-            error={errors.loanAmount}
-            numericFormat="integer"
-          />
-
-          <InputField
-            label="Interest Rate"
-            value={interestRate}
-            onChangeText={setInterestRate}
-            placeholder="e.g., 6.5"
-            prefix="%"
-            error={errors.interestRate}
-            numericFormat="decimal"
-          />
-
-          <InputField
-            label="Loan Term (Years)"
-            value={loanTermYears}
-            onChangeText={setLoanTermYears}
-            placeholder="e.g., 30"
-            error={errors.loanTermYears}
-            numericFormat="integer"
-          />
-
-          {/* Payment Type Selector */}
-          <View style={styles.paymentTypeContainer}>
-            <TouchableOpacity
-              style={[styles.paymentTypeButton, paymentType === 'oneTime' && styles.paymentTypeButtonActive]}
-              onPress={() => setPaymentType('oneTime')}
-            >
-              <Text style={[styles.paymentTypeButtonText, paymentType === 'oneTime' && { color: Colours.background.primary }]}>One-Time Payment</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[styles.paymentTypeButton, paymentType === 'monthly' && styles.paymentTypeButtonActive]}
-              onPress={() => setPaymentType('monthly')}
-            >
-              <Text style={[styles.paymentTypeButtonText, paymentType === 'monthly' && { color: Colours.background.primary }]}>Monthly Recurring</Text>
-            </TouchableOpacity>
-          </View>
-
-          <InputField
-            label={paymentType === 'oneTime' ? "One-Time Extra Payment" : "Extra Monthly Payment"}
-            value={formatNumberWithCommas(extraPayment)}
-            onChangeText={(text) => setExtraPayment(cleanNumber(text))}
-            placeholder={paymentType === 'oneTime' ? "e.g., 50,000" : "e.g., 100"}
-            prefix="$"
-            error={errors.extraPayment}
-            numericFormat="integer"
-          />
-
-          <TouchableOpacity style={styles.clearButton} onPress={handleClear}>
-            <Ionicons name="close-circle" size={20} color={Colours.text.secondary} />
-            <Text style={styles.clearButtonText}>Clear</Text>
-          </TouchableOpacity>
-
-          <View style={styles.tipContainer}>
-            <Ionicons name="information-circle" size={20} color={Colours.primary} />
-            <Text style={styles.tipText}>
-              <Text style={styles.tipBold}>Tip:</Text> Even small extra payments can save 
-              thousands in interest and years off your loan term.
+          {/* Header */}
+          <View style={styles.header}>
+            <Ionicons name="calculator" size={32} color={Colours.primary} />
+            <Text style={styles.headerTitle}>Mortgage Calculator</Text>
+            <Text style={styles.headerSubtitle}>
+              Calculate your savings with extra mortgage payments
             </Text>
           </View>
-        </View>
 
-        {/* Results Section */}
-        {results && (
-          <View style={styles.resultsSection}>
-            {/* Monthly Payment Card */}
-            <View style={styles.monthlyPaymentCard}>
-              <View style={styles.monthlyPaymentTitleContainer}>
-                <Text style={styles.monthlyPaymentTitle}>Monthly Payment</Text>
-                <InfoButton note="This is your estimated monthly mortgage payment, including principal and interest, without any extra payments." />
-              </View>
-              <Text style={styles.monthlyPaymentValue}>
-                {formatCurrency(results.monthlyPaymentRegular)}
+          {/* Input Section */}
+          <View style={styles.inputSection}>
+            <View style={styles.sectionHeader}>
+              <Ionicons name="card" size={20} color={Colours.primary} />
+              <Text style={styles.sectionTitle}>Loan Details</Text>
+            </View>
+
+            <InputField
+              label="Loan Amount"
+              value={formatNumberWithCommas(loanAmount)}
+              onChangeText={(text) => setLoanAmount(cleanNumber(text))}
+              placeholder="e.g., 300,000"
+              prefix="$"
+              error={errors.loanAmount}
+              numericFormat="integer"
+            />
+
+            <InputField
+              label="Interest Rate"
+              value={interestRate}
+              onChangeText={setInterestRate}
+              placeholder="e.g., 6.5"
+              prefix="%"
+              error={errors.interestRate}
+              numericFormat="decimal"
+            />
+
+            <InputField
+              label="Loan Term (Years)"
+              value={loanTermYears}
+              onChangeText={setLoanTermYears}
+              placeholder="e.g., 30"
+              error={errors.loanTermYears}
+              numericFormat="integer"
+            />
+
+            {/* Payment Type Selector */}
+            <View style={styles.paymentTypeContainer}>
+              <TouchableOpacity
+                style={[styles.paymentTypeButton, paymentType === 'oneTime' && styles.paymentTypeButtonActive]}
+                onPress={() => setPaymentType('oneTime')}
+              >
+                <Text style={[styles.paymentTypeButtonText, paymentType === 'oneTime' && { color: Colours.background.primary }]}>One-Time Payment</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.paymentTypeButton, paymentType === 'monthly' && styles.paymentTypeButtonActive]}
+                onPress={() => setPaymentType('monthly')}
+              >
+                <Text style={[styles.paymentTypeButtonText, paymentType === 'monthly' && { color: Colours.background.primary }]}>Monthly Recurring</Text>
+              </TouchableOpacity>
+            </View>
+
+            <InputField
+              label={paymentType === 'oneTime' ? "One-Time Extra Payment" : "Extra Monthly Payment"}
+              value={formatNumberWithCommas(extraPayment)}
+              onChangeText={(text) => setExtraPayment(cleanNumber(text))}
+              placeholder={paymentType === 'oneTime' ? "e.g., 50,000" : "e.g., 100"}
+              prefix="$"
+              error={errors.extraPayment}
+              numericFormat="integer"
+            />
+
+            <TouchableOpacity style={styles.clearButton} onPress={handleClear}>
+              <Ionicons name="close-circle" size={20} color={Colours.text.secondary} />
+              <Text style={styles.clearButtonText}>Clear</Text>
+            </TouchableOpacity>
+
+            <View style={styles.tipContainer}>
+              <Ionicons name="information-circle" size={20} color={Colours.primary} />
+              <Text style={styles.tipText}>
+                <Text style={styles.tipBold}>Tip:</Text> Even small extra payments can save
+                thousands in interest and years off your loan term.
               </Text>
-              <Text style={styles.monthlyPaymentLabel}>Regular monthly payment</Text>              
+            </View>
+          </View>
+
+          {/* Results Section */}
+          {results && (
+            <View style={styles.resultsSection}>
+              {/* Monthly Payment Card */}
+              <View style={styles.monthlyPaymentCard}>
+                <View style={styles.monthlyPaymentTitleContainer}>
+                  <Text style={styles.monthlyPaymentTitle}>Monthly Payment</Text>
+                  <InfoButton note="This is your estimated monthly mortgage payment, including principal and interest, without any extra payments." />
+                </View>
+                <Text style={styles.monthlyPaymentValue}>
+                  {formatCurrency(results.monthlyPaymentRegular)}
+                </Text>
+                <Text style={styles.monthlyPaymentLabel}>Regular monthly payment</Text>
+                {hasExtraPayment && (
+                  <View style={styles.extraPaymentContainer}>
+                    <View style={styles.separator} />
+                    {paymentType === 'oneTime' ? (
+                      // For one-time payments, show the upfront cost + monthly payment
+                      <View style={styles.oneTimePaymentDisplay}>
+                        <Text style={styles.oneTimeUpfrontLabel}>Upfront Payment:</Text>
+                        <Text style={styles.oneTimeUpfrontValue}>
+                          {formatCurrency(parseFloat(cleanNumber(extraPayment)))}
+                        </Text>
+                        <Text style={styles.oneTimePlusLabel}>+</Text>
+                        <Text style={styles.oneTimeMonthlyLabel}>Monthly Payment:</Text>
+                        <Text style={styles.extraPaymentValue}>
+                          {formatCurrency(results.monthlyPaymentExtra)}
+                        </Text>
+                        <Text style={styles.extraPaymentLabel}>
+                          Reduced monthly payment after upfront payment
+                        </Text>
+                      </View>
+                    ) : (
+                      // For monthly payments, show the combined monthly payment
+                      <>
+                        <Text style={styles.extraPaymentValue}>
+                          {formatCurrency(results.monthlyPaymentExtra)}
+                        </Text>
+                        <Text style={styles.extraPaymentLabel}>
+                          With extra monthly payment
+                        </Text>
+                      </>
+                    )}
+                  </View>
+                )}
+              </View>
+
+              {/* Savings Cards */}
               {hasExtraPayment && (
-                <View style={styles.extraPaymentContainer}>
-                  <View style={styles.separator} />
-                  <Text style={styles.extraPaymentValue}>
-                    {formatCurrency(results.monthlyPaymentExtra)}
-                  </Text>
-                  <Text style={styles.extraPaymentLabel}>
-                    {paymentType === 'oneTime' ? 'With extra one-time payment' : 'With extra payment'}
-                  </Text>
+                <View style={styles.savingsCards}>
+                  <View style={styles.savingsCardHeader}>
+                    <ResultCard
+                      title="Interest Savings"
+                      value={formatCurrency(results.interestSavings)}
+                      subtitle="Total interest saved over loan term"
+                      color={Colours.success}
+                      icon="trending-down"
+                    />
+                    <InfoButton note="This is the total amount of interest you save by making extra payments compared to only making regular payments." />
+                  </View>
+
+                  <View style={styles.savingsCardHeader}>
+                    <ResultCard
+                      title="Time Savings"
+                      value={`${results.timeSavings.years}y ${results.timeSavings.months}m`}
+                      subtitle="Loan paid off earlier"
+                      color={Colours.accent}
+                      icon="time"
+                    />
+                    <InfoButton note="This is the amount of time (years and months) you save on your loan term by making extra payments." />
+                  </View>
                 </View>
               )}
-            </View>
 
-            {/* Savings Cards */}
-            {hasExtraPayment && (
-              <View style={styles.savingsCards}>
-                <View style={styles.savingsCardHeader}>
-                  <ResultCard
-                    title="Interest Savings"
-                    value={formatCurrency(results.interestSavings)}
-                    subtitle="Total interest saved over loan term"
-                    color={Colours.success}
-                    icon="trending-down"
-                  />
-                  <InfoButton note="This is the total amount of interest you save by making extra payments compared to only making regular payments." />
-                </View>
-                
-                <View style={styles.savingsCardHeader}>
-                  <ResultCard
-                    title="Time Savings"
-                    value={`${results.timeSavings.years}y ${results.timeSavings.months}m`}
-                    subtitle="Loan paid off earlier"
-                    color={Colours.accent}
-                    icon="time"
-                  />
-                  <InfoButton note="This is the amount of time (years and months) you save on your loan term by making extra payments." />
-                </View>
-              </View>
-            )}
-
-            {/* Loan Comparison */}
-            <LoanComparison results={results} extraPaymentType={hasExtraPayment ? paymentType : undefined} />
+              {/* Loan Comparison */}
+              <LoanComparison results={results} extraPaymentType={hasExtraPayment ? paymentType : undefined} />
 
             </View>
-        )}
-      </ScrollView>
+          )}
+        </ScrollView>
       </KeyboardAvoidingView>
     </SafeAreaView>
   );
@@ -431,6 +452,30 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
+  },
+  oneTimePaymentDisplay: {
+    alignItems: 'center',
+  },
+  oneTimeUpfrontLabel: {
+    fontSize: 12,
+    color: Colours.text.secondary,
+    marginBottom: 4,
+  },
+  oneTimeUpfrontValue: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: Colours.accent,
+    marginBottom: 8,
+  },
+  oneTimePlusLabel: {
+    fontSize: 16,
+    color: Colours.text.secondary,
+    marginBottom: 8,
+  },
+  oneTimeMonthlyLabel: {
+    fontSize: 12,
+    color: Colours.text.secondary,
+    marginBottom: 4,
   },
 });
 

--- a/src/utils/mortgageCalculations.ts
+++ b/src/utils/mortgageCalculations.ts
@@ -63,43 +63,79 @@ export const calculateMortgage = (inputs: LoanInputs): MortgageResults | null =>
   const totalInterestRegular = (monthlyPaymentRegular * totalPayments) - loanAmount;
   const totalAmountRegular = loanAmount + totalInterestRegular;
 
-  // Calculate with extra payments (one-time or monthly recurring)
+  // Calculate with extra payments
   let balanceExtra = loanAmount;
   let totalInterestExtra = 0;
   let paymentsWithExtra = 0;
+  let monthlyPaymentExtraCalculated: number;
+  let totalAmountExtra: number;
 
-  // Apply one-time payment at the start of the extra payment scenario
-  if (paymentType === 'oneTime' && extraPayment > 0) {
-    balanceExtra -= extraPayment;
+  if (paymentType === 'oneTime') {
+    // Option A: Same Term, Recalculated Payment
+    const adjustedLoanAmount = Math.max(0, loanAmount - extraPayment);
+
+    if (adjustedLoanAmount === 0) {
+      monthlyPaymentExtraCalculated = 0;
+      balanceExtra = 0;
+      totalInterestExtra = 0;
+      paymentsWithExtra = 0;
+    } else if (adjustedLoanAmount < 0.01) { // Handle very small amounts
+      monthlyPaymentExtraCalculated = adjustedLoanAmount;
+      totalInterestExtra = 0;
+      paymentsWithExtra = 1;
+      balanceExtra = 0;
+    } else {
+      monthlyPaymentExtraCalculated = adjustedLoanAmount * (monthlyRate * Math.pow(1 + monthlyRate, totalPayments)) /
+                                      (Math.pow(1 + monthlyRate, totalPayments) - 1);
+
+      balanceExtra = adjustedLoanAmount;
+      totalInterestExtra = 0;
+      paymentsWithExtra = 0;
+
+      // Simulate payments with the newly adjusted monthly payment
+      while (balanceExtra > 0.01 && paymentsWithExtra < totalPayments * 2) { // Safety checks
+        const interestPayment = balanceExtra * monthlyRate;
+        const principalPayment = monthlyPaymentExtraCalculated - interestPayment;
+        const actualPrincipalPaid = Math.min(principalPayment, balanceExtra);
+
+        totalInterestExtra += interestPayment;
+        balanceExtra -= actualPrincipalPaid;
+        paymentsWithExtra++;
+      }
+    }
+    
+    // For one-time payments, total includes the extra payment
+    totalAmountExtra = loanAmount + extraPayment + totalInterestExtra;
+  } else { // paymentType === 'monthly'
+    // Simulate payments with regular monthly payment + extra monthly payment
+    monthlyPaymentExtraCalculated = monthlyPaymentRegular + extraPayment;
+    balanceExtra = loanAmount;
+    totalInterestExtra = 0;
+    paymentsWithExtra = 0;
+
+    while (balanceExtra > 0.01 && paymentsWithExtra < totalPayments * 2) { // Safety checks
+      const interestPayment = balanceExtra * monthlyRate;
+      const principalPayment = monthlyPaymentExtraCalculated - interestPayment;
+      const actualPrincipalPaid = Math.min(principalPayment, balanceExtra);
+
+      totalInterestExtra += interestPayment;
+      balanceExtra -= actualPrincipalPaid;
+      paymentsWithExtra++;
+    }
+    
+    // For monthly payments, total is principal + interest (extra payments are part of the payment stream)
+    totalAmountExtra = loanAmount + totalInterestExtra;
   }
 
-  const effectiveMonthlyExtraPayment = (paymentType === 'monthly') ? extraPayment : 0;
-
-  // Recalculate monthly payment based on potentially reduced principal for extra payment scenario
-  // This is crucial if a one-time payment significantly reduces the principal
-  const monthlyPaymentForExtra = balanceExtra * (monthlyRate * Math.pow(1 + monthlyRate, totalPayments)) / 
-                                 (Math.pow(1 + monthlyRate, totalPayments) - 1);
-
-  while (balanceExtra > 0 && paymentsWithExtra < totalPayments) {
-    const interestPayment = balanceExtra * monthlyRate;
-    const principalPayment = monthlyPaymentForExtra - interestPayment;
-    const totalPrincipalPayment = Math.min(principalPayment + effectiveMonthlyExtraPayment, balanceExtra);
-
-    totalInterestExtra += interestPayment;
-    balanceExtra -= totalPrincipalPayment;
-    paymentsWithExtra++;
-  }
-
-  const totalAmountExtra = loanAmount + totalInterestExtra; // Use original loanAmount for total
   const interestSavings = totalInterestRegular - totalInterestExtra;
-  const timeSavings = totalPayments - paymentsWithExtra;
+  const timeSavings = Math.max(0, totalPayments - paymentsWithExtra);
   const yearsSaved = Math.floor(timeSavings / 12);
   const monthsSaved = timeSavings % 12;
 
   return {
-    monthlyPayment: monthlyPaymentRegular,
+    monthlyPayment: monthlyPaymentRegular, // Base monthly payment
     monthlyPaymentRegular,
-    monthlyPaymentExtra: paymentType === 'oneTime' ? monthlyPaymentRegular + extraPayment : monthlyPaymentRegular + effectiveMonthlyExtraPayment,
+    monthlyPaymentExtra: monthlyPaymentExtraCalculated,
     totalInterestRegular,
     totalAmountRegular,
     totalInterestExtra,


### PR DESCRIPTION
This commit addresses critical feedback regarding the mathematical accuracy and user experience of the one-time extra payment calculation within the mortgage calculator.

Previously, one-time payments did not adjust monthly payments, leading to unrealistic amortization behavior. This update aligns the calculator with real-world mortgage practices where a principal reduction recalculates the monthly payment over the same loan term.

Problem Addressed:
- One-time extra payments reduced the balance, but monthly payments stayed the same.
- This resulted in abnormally high principal portions and a misleading display.

Solution Implemented:
- Recalculated monthly payment after a one-time lump-sum payment using Option A: Same Term, Recalculated Payment.
- Reduced loan amount is now used to compute a new monthly payment for the remaining term.
- Improved display in MortgageCalculatorScreen and LoanComparison to clearly separate upfront and recurring payments.

Code Changes:
1. src/utils/mortgageCalculations.ts
   - Refactored one-time payment logic for accurate amortization.
   - Added safety checks to avoid infinite loops due to floating-point errors.
   - Updated return values in MortgageResults with accurate payment breakdown.

2. src/screens/MortgageCalculatorScreen.tsx
   - Enhanced UI to show upfront vs monthly payment clearly.
   - Added new styles for improved clarity.

3. src/components/LoanComparison.tsx
   - Updated labels to reflect payment structure: - 'Total Amount (including upfront payment)' - 'Monthly Payment (after upfront payment)'

Overall, this change improves realism, accuracy, and clarity for users exploring one-time extra payments.